### PR TITLE
Adding basic parts to techfabs

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -551,6 +551,8 @@
     - MedicalBoardsStatic
     - MedicalBoardsStaticGoob
     - PowerCellsStatic
+    # ShibaStation Packs
+    - MedicalPartsStatic
     dynamicPacks:
     - Chemistry
     # Goobstation Packs

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -12,6 +12,13 @@
   - OreProcessorMachineCircuitboard
   - SalvageMagnetMachineCircuitboard
 
+- type: latheRecipePack
+  id: CargoPartsStatic
+  recipes:
+  - MicroManipulatorStockPart
+  - MatterBinStockPart
+  - CapacitorStockPart
+
 ## Dynamic
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -81,6 +81,14 @@
   - CondenserMachineCircuitBoard
   - HotplateMachineCircuitboard
 
+- type: latheRecipePack
+  id: MedicalPartsStatic
+  recipes:
+  - MicroManipulatorStockPart
+  - MatterBinStockPart
+  - CapacitorStockPart
+  - CableStack
+
 ## Dynamic
 
 # Shared with protolathe

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -34,6 +34,14 @@
   - BoozeDispenserMachineCircuitboard
   - SodaDispenserMachineCircuitboard
 
+- type: latheRecipePack
+  id: ServicePartsStatic
+  recipes:
+  - MicroManipulatorStockPart
+  - MatterBinStockPart
+  - CapacitorStockPart
+  - CableStack
+
 ## Dynamic
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -86,6 +86,8 @@
     - CablesStatic
     - PowerCellsStatic
     - MiningToolsStatic
+    # ShibaStation Packs
+    - CargoPartsStatic
     dynamicPacks:
     - AdvancedTools
     - Mining
@@ -212,6 +214,8 @@
     - PowerCellsStatic
     - LatheMiscStatic
     - ChemistryStatic
+    # ShibaStation Packs
+    - ServicePartsStatic
     dynamicPacks:
     - Janitor
     - Instruments


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added Manipulators, Matter bins, Capacitors and LV cables to techfabs with printable machine circuit boards

## Why / Balance
To allow departments to assemble there machine boards without having to find a separate lathe.

## Technical details
Added lathe recipe packs to cargo, medical and service techfabs.
Updated the goob and wizden pack lists for each techfab.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added parts for machine construction to some techfabs.
